### PR TITLE
Fix issue with deprecated download location for Butler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL "com.github.actions.description"="Publishes releases to Itch.io using Butl
 LABEL "com.github.actions.icon"="upload"
 LABEL "com.github.actions.color"="white"
 
+RUN dnf install unzip -y
+
 # Install Butler
 RUN curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default \
     && unzip butler.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ LABEL "com.github.actions.icon"="upload"
 LABEL "com.github.actions.color"="white"
 
 # Install Butler
-ADD https://dl.itch.ovh/butler/linux-amd64/head/butler /usr/bin/
-RUN chmod +x /usr/bin/butler
-RUN butler upgrade --assume-yes
+RUN curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default \
+    && unzip butler.zip \
+    && cp butler /usr/bin \
+    && chmod +x /usr/bin/butler
 
 # Run butler push
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -e
 
-mkdir -p ~/.config/itch
-echo $BUTLER_CREDENTIALS > ~/.config/itch/butler_creds
+export BUTLER_API_KEY=$BUTLER_CREDENTIALS
 
 versionArgument=""
 


### PR DESCRIPTION
As noted in the [Butler documentation](https://itch.io/docs/butler/installing.html) the dl.itch.ovh domain is deprecated for installing Butler.
On every trigger of my workflow it failed 2/3 of the times, due to the server not responding.
After this change it will be installed without problems (upgrading isn't needed either, since we install the latest stable version.

Also changed the ADD to COPY, mostly because in the [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) of Docker they said to prefer COPY over ADD