### PR TITLE
Store Butler credentials in env-var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -e
 
-mkdir -p ~/.config/itch
-echo $BUTLER_CREDENTIALS > ~/.config/itch/butler_creds
+export BUTLER_API_KEY=$BUTLER_CREDENTIALS
 
 versionArgument=""
 


### PR DESCRIPTION
The [documentation of Butler](https://itch.io/docs/butler/login.html#running-butler-from-ci-builds-travis-ci-gitlab-ci-etc) (and a runtime warning notification) suggested to put the api-key in an environment var.

Since the BUTLER_CREDENTIALS is already an environment var, it would be more logic to rename that param - but that would cause a breaking change. So therefor I opted to just export the key as a new env-var 😁