### PR TITLE
Fix typo in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 # Butler Push
 
-This action pushes packages to itch.io with butler to easily automated releases.
+This action pushes packages to itch.io with butler to easily automate releases.
 
 ## Usage
 


### PR DESCRIPTION
I _think_ it should be `to easily automate releases` instead of `to easily automated releases`...?