### PR TITLE
chore: increase rocky Linux version to 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:8
+FROM rockylinux:9
 
 LABEL "com.github.actions.name"="Butler Push"
 LABEL "com.github.actions.description"="Publishes releases to Itch.io using Butler"


### PR DESCRIPTION
This update was done to get a newer version of glibc, which is required with the latest update of Butler.